### PR TITLE
Empty vcfs

### DIFF
--- a/modules/clockworkModules.nf
+++ b/modules/clockworkModules.nf
@@ -250,7 +250,7 @@ process minos {
     if [[ \$n_variants_bcf == 0 ]] ;
     then
         cp ${cortex_vcf} ${minos_vcf}
-    elif [[ \$n_variants_cortex == 0 ]]
+    elif [[ \$n_variants_cortex == 0 ]] ; then
         cp ${bcftools_vcf} ${minos_vcf}
     else
         minos adjudicate --force --reads ${bam} minos ref.fa ${bcftools_vcf} ${cortex_vcf}

--- a/modules/clockworkModules.nf
+++ b/modules/clockworkModules.nf
@@ -249,14 +249,15 @@ process minos {
 
     if [[ \$n_variants_bcf == 0 ]] ;
     then
-        cp ${cortex_vcf} ${minos_vcf}
-    elif [[ \$n_variants_cortex == 0 ]] ; then
-        cp ${bcftools_vcf} ${minos_vcf}
-    else
-        minos adjudicate --force --reads ${bam} minos ref.fa ${bcftools_vcf} ${cortex_vcf}
-        cp minos/final.vcf ${minos_vcf}
-        rm -rf minos
-    fi
+        grep "^#" ${cortex_vcf} > ${bcftools_vcf}
+    elif [[ \$n_variants_cortex == 0 ]]
+    then
+        grep "^#" ${bcftools_vcf} > ${cortex_vcf}
+    fi 
+        
+    minos adjudicate --force --reads ${bam} minos ref.fa ${bcftools_vcf} ${cortex_vcf}
+    cp minos/final.vcf ${minos_vcf}
+    rm -rf minos
 
     top_hit=\$(jq -r '.top_hit.name' ${report_json})
 

--- a/modules/clockworkModules.nf
+++ b/modules/clockworkModules.nf
@@ -11,9 +11,6 @@ process getRefFromJSON {
     val(do_we_align)
     val(sample_name)
     
-    //when:
-    //do_we_align =~ /NOW\_ALIGN\_TO\_REF\_${sample_name}/
-    
     output:
     stdout
     
@@ -250,7 +247,8 @@ process minos {
     n_variants_bcf=\$(grep -i "^#" ${bcftools_vcf} | wc -l)
     n_variants_cortex=\$(grep -i "^#" ${cortex_vcf} | wc -l)
 
-    if [[ \$n_variants_bcf == 0 ]]
+    if [[ \$n_variants_bcf == 0 ]] ;
+    then
         cp ${cortex_vcf} ${minos_vcf}
     elif [[ \$n_variants_cortex == 0 ]]
         cp ${bcftools_vcf} ${minos_vcf}

--- a/modules/clockworkModules.nf
+++ b/modules/clockworkModules.nf
@@ -196,12 +196,17 @@ process callVarsCortex {
 
     script:
     cortex_vcf = "${sample_name}.cortex.vcf"
-
+    cortex_original = "cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.raw.vcf"
+    
     """
     cp -r ${ref_dir}/* .
 
     clockwork cortex . ${bam} cortex ${sample_name}
-    cp cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.raw.vcf ${cortex_vcf}
+    if [[ -f ${cortex_original} ]]
+        cp cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.raw.vcf ${cortex_vcf}
+    else
+        touch ${cortex_vcf}
+    fi
     """
 
     stub:

--- a/workflows/clockwork.nf
+++ b/workflows/clockwork.nf
@@ -32,7 +32,9 @@ workflow clockwork {
       getRefCortex(alignToRef.out.alignToRef_bam)
       callVarsCortex(alignToRef.out.alignToRef_bam, getRefCortex.out)
 
-      minos(alignToRef.out.alignToRef_bam.join(callVarsCortex.out.cortex_vcf, by: 0).join(callVarsMpileup.out.mpileup_vcf, by: 0))
+      minos(alignToRef.out.alignToRef_bam
+            .join(callVarsCortex.out.cortex_vcf, by: 0)
+            .join(callVarsMpileup.out.mpileup_vcf, by: 0))
 
       gvcf(alignToRef.out.alignToRef_bam.join(minos.out.minos_vcf, by: 0))
 


### PR DESCRIPTION
Deal with empty VCFs (namely created by Cortex). In short the header of the non-failing VCF is used to populate a blank VCF